### PR TITLE
Website for managing override

### DIFF
--- a/Occupancy
+++ b/Occupancy
@@ -8,6 +8,7 @@ IRC_BOTD="/opt/uas/Occupancy/ocs.sh"
 OPTIONS=""
 #Path to the bot's PID file e.g. /path/to/bot.pid
 pid_path=/var/run/ocs.pid
+webserver_pid_path=/var/run/ocs_webserver.pid
  
 do_start()
 {
@@ -15,7 +16,7 @@ do_start()
                 echo "Occupancy is already running, or it crashed and the pid file still exists! Try stop/restart, or removing the PID file first."
         else
                 echo "Starting UAS Occupancy."
-                nohup python /opt/uas/Occupancy/webserver.py &
+                nohup python /opt/uas/Occupancy/webserver.py &> /opt/uas/Occupancy_webserver.log &
                 nohup $IRC_BOTD $OPTIONS &> /opt/uas/Occupancy.log &
                 if [ $? -eq 0 ]; then
                         echo "UAS Occupancy successfully started."
@@ -30,7 +31,7 @@ do_start()
 do_status()
 {
         if [ -f $pid_path ]; then
-                echo "UAS Occupancy is running with a pid of `cat $pid_path`"
+                echo "UAS Occupancy is running with a pid of `cat $pid_path`. UAS Occupancy webserver is running with a pid of `cat $webserver_pid_path`."
         else
                 echo "UAS Occupancy is not running, or has not generated a pid file."
         fi
@@ -42,6 +43,7 @@ do_stop()
     echo "Stopping UAS IRC bot"
         if [ -f $pid_path ]; then
                 kill -6 `cat $pid_path` 2> /dev/null
+                kill -6 `cat $webserver_pid_path` 2> /dev/null
                 if [ $? -eq 0 ]; then
                         echo "UAS Occupancy stopped."
                         logger "Gracefully killed UAS Occupancy."
@@ -51,6 +53,7 @@ do_stop()
         else
                 echo "UAS Occupancy is not running, or has not generated a pid file."
         fi
+    rm $webserver_pid_path
     rm $pid_path
     return 0
 }

--- a/Occupancy
+++ b/Occupancy
@@ -15,6 +15,7 @@ do_start()
                 echo "Occupancy is already running, or it crashed and the pid file still exists! Try stop/restart, or removing the PID file first."
         else
                 echo "Starting UAS Occupancy."
+                nohup python /opt/uas/Occupancy/webserver.py &
                 nohup $IRC_BOTD $OPTIONS &> /opt/uas/Occupancy.log &
                 if [ $? -eq 0 ]; then
                         echo "UAS Occupancy successfully started."

--- a/ocs.cfg
+++ b/ocs.cfg
@@ -12,6 +12,7 @@
 
 # PID file location
 OCS_PID_FILE_PATH=/var/run/ocs.pid
+OCS_PID_WEBSERVER_PATH=/var/run/ocs_webserver.pid
 
 # Logging file
 OCS_LOGFILE=/opt/uas/Occupancy/occupancy.log

--- a/ocs.cfg
+++ b/ocs.cfg
@@ -30,6 +30,7 @@ OCS_UAS_WALL_ARCHIVE_FILEPATH=$OCS_UAS_URL/thewall/archive
 
 # Override
 OCS_OVERRIDE_LSUSB_VALUE="0781:5530"
+OCS_OVERRIDE_FILE=/opt/uas/Occupancy/override.txt
 
 # Temporary File locations
 OCS_TMP_LIGHT=/tmp/ocs.jpg

--- a/ocs.sh
+++ b/ocs.sh
@@ -49,6 +49,13 @@ getWallPicture ()
     sleep 1
 }
 
+# checkOverride()
+# Get the current override status from the website
+checkOverride()
+{
+  [ -f ${OVERRIDE_FILE} ] || [ lsusb | grep "${OCS_OVERRIDE_LSUSB_VALUE}" ]
+}
+
 # getBrightness()
 # Use camera to determine ceiling_light brightness level
 #   * sets $level variable
@@ -131,7 +138,7 @@ main ()
         getBrightness
         
         # Override check
-        if lsusb | grep "${OCS_OVERRIDE_LSUSB_VALUE}" ; then
+        if checkOverride(); then
             is_overridden=true
         else
             is_overridden=false

--- a/webserver.py
+++ b/webserver.py
@@ -1,0 +1,68 @@
+from BaseHTTPServer import BaseHTTPRequestHandler,HTTPServer
+from configobj import ConfigObj
+import os.path
+import signal
+PORT_NUMBER = 8000
+
+def handler(signum, frame):
+    print "Caught signal: " + str(signum) + ", shutting down gracefully"
+    destroy_pid()
+    exit()
+    return
+
+def create_pid(location):
+    f = open(location, 'w')
+    f.write(str(os.getpid()))
+    f.close()
+    return os.getpid()
+
+def destroy_pid():
+    os.remove(cfg['OCS_PID_WEBSERVER_PATH'])
+    return
+
+#This class will handles any incoming request from
+#the browser 
+class myHandler(BaseHTTPRequestHandler):
+    #Handler for the GET requests
+    def do_GET(self):
+        # Turn on the override and then redirect to homepage
+        if self.path == "/on":
+            self.send_response(301)
+            self.send_header('Location', '/')
+            open(override_file_loc, "w")
+            print "Creating file"
+            self.end_headers()
+            return
+        # Turn off the override and then redirect to homepage
+        elif self.path == "/off":
+            self.send_response(301)
+            self.send_header('Location', '/')
+            os.remove(override_file_loc)
+            print "Deleted file"
+            self.end_headers()
+            return
+        else:
+            self.send_response(200)
+            self.send_header('Content-type','text/html')
+            self.end_headers()
+
+        if os.path.isfile(override_file_loc):
+            self.wfile.write("<h1>Override is on</h1><a href='off'>Turn off override</a>")
+        else:
+            self.wfile.write("<h1>Override is off</h1><a href='on'>Turn on override</a>")
+        return
+
+# Do setup stuff like creating pid file
+cfg = ConfigObj('ocs.cfg')
+override_file_loc = cfg['OCS_OVERRIDE_FILE']
+create_pid(cfg['OCS_PID_WEBSERVER_PATH']);
+signal.signal(signal.SIGABRT, handler)
+
+#Create a web server and define the handler to manage the
+#incoming request
+server = HTTPServer(('', PORT_NUMBER), myHandler)
+print 'Started httpserver on port ' , PORT_NUMBER
+
+#Wait forever for incoming htto requests
+server.serve_forever()
+


### PR DESCRIPTION
This change creates a simple python web server for setting the override status.  The user is presented with a page that shows the current status of the override and given the option to turn it off/on based on the current status.  

![](https://i.imgur.com/G2rL8kf.png)

When the user clicks the link to turn on the override, it creates an empty text file as specified in the config file.  The ocs.sh script now looks for this file when determining the current override status.  When the user clicks the link to turn the override off, it deletes that file.