### PR TITLE
fix closing script not running

### DIFF
--- a/ocs.cfg
+++ b/ocs.cfg
@@ -49,5 +49,5 @@ OCS_IRC_SERVICE="Occupancy"
 OCS_IRC_KEY="1s2d3fq"
 
 # Check In
-OCS_CHECKIN_SCRIPT_CLOSING_COMMAND=/opt/uas/Checkin/checkin.py
+OCS_CHECKIN_SCRIPT=/opt/uas/Checkin/checkin.py
 OCS_CHECKIN_FILE=/opt/uas/Checkin/ciusers


### PR DESCRIPTION
Renamed OCS_CHECKIN_SCRIPT_CLOSING_COMMAND variable to match
OCS_CHECKIN_SCRIPT referred to in the ocs.sh